### PR TITLE
feat: support multiple issue types (CSV) in deployment pipeline filters

### DIFF
--- a/.github/actions/_shared/utils.js
+++ b/.github/actions/_shared/utils.js
@@ -20,6 +20,13 @@ function norm(value, options = {}) {
   return result.replace(/\s+/g, " ").trim();
 }
 
+function normList(value, options = {}) {
+  return String(value ?? "")
+    .split(",")
+    .map((item) => norm(item, options))
+    .filter((item) => item.length > 0);
+}
+
 function appendOutput(key, value) {
   if (!process.env.GITHUB_OUTPUT) return;
   fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value ?? ""}\n`);
@@ -157,6 +164,7 @@ function resolveCurrentIterationTitle(iterationField, now = new Date()) {
 module.exports = {
   reqEnv,
   norm,
+  normList,
   appendOutput,
   appendOutputs,
   readJsonFile,

--- a/.github/actions/build-us-column-message/action.yaml
+++ b/.github/actions/build-us-column-message/action.yaml
@@ -10,11 +10,11 @@ inputs:
     description: "Number of issues found"
   empty_message:
     required: false
-    default: "ℹ️ Aucune User Story trouvée dans la colonne Recette."
+    default: "ℹ️ Aucun élément trouvé dans la colonne Recette."
     description: "Message to display when no issue is found"
   header_message:
     required: false
-    default: "🧪 User Stories actuellement dans Recette :"
+    default: "🧪 Éléments actuellement dans Recette :"
     description: "Header message displayed before the list"
 
 outputs:
@@ -51,7 +51,7 @@ runs:
           if [ "${COUNT}" = "0" ]; then
             printf '%s\n' "${EMPTY_MESSAGE}"
           else
-            ISSUE_LINES="$(echo "${ISSUES_JSON}" | jq -r '.[] | "- [US#\(.number)](\(.url)) : \(.title | gsub("\\["; "(") | gsub("\\]"; ")"))"')"
+            ISSUE_LINES="$(echo "${ISSUES_JSON}" | jq -r '.[] | "- **[\(.issue_type // "?")]** [#\(.number)](\(.url)) : \(.title | gsub("\\["; "(") | gsub("\\]"; ")"))"')"
             printf '%s\n\n%s\n' "${HEADER_MESSAGE}" "${ISSUE_LINES}"
           fi
 

--- a/.github/actions/check-us-done/action.yaml
+++ b/.github/actions/check-us-done/action.yaml
@@ -15,8 +15,14 @@ inputs:
 
 outputs:
   should_run:
-    description: "true if parent is User Story AND all its sub-issues are done/closed"
+    description: "true if parent's issue type matches one of us_issue_type AND all its sub-issues are done/closed"
     value: ${{ steps.check.outputs.should_run }}
+  parent_issue_title:
+    description: "Title of the parent issue, empty if should_run is false"
+    value: ${{ steps.check.outputs.parent_issue_title }}
+  parent_issue_type:
+    description: "Issue type name of the parent issue, empty if should_run is false"
+    value: ${{ steps.check.outputs.parent_issue_type }}
 
 runs:
   using: "composite"

--- a/.github/actions/check-us-done/action.yaml
+++ b/.github/actions/check-us-done/action.yaml
@@ -11,7 +11,7 @@ inputs:
   us_issue_type:
     required: false
     default: "User Story"
-    description: "Name of the User Story issue type in the repo (used to filter issues to move, e.g. if there are multiple issue types in the project)"
+    description: "Comma-separated list of issue type names to accept as parent (e.g. \"User Story,Enabler Story\"). Defaults to \"User Story\" only."
 
 outputs:
   should_run:

--- a/.github/actions/check-us-done/check-us-done.js
+++ b/.github/actions/check-us-done/check-us-done.js
@@ -1,4 +1,4 @@
-const { reqEnv, norm, normList, appendOutput } = require("../_shared/utils");
+const { reqEnv, norm, normList, appendOutput, appendOutputs } = require("../_shared/utils");
 const { gql } = require("../_shared/github");
 
 (async () => {
@@ -12,7 +12,11 @@ const { gql } = require("../_shared/github");
     if (reason) {
       console.log(`ℹ️ ${reason}`);
     }
-    appendOutput("should_run", "false");
+    appendOutputs({
+      should_run: "false",
+      parent_issue_title: "",
+      parent_issue_type: "",
+    });
   };
 
   const query = `
@@ -21,6 +25,7 @@ const { gql } = require("../_shared/github");
         ... on Issue {
           parent {
             ... on Issue {
+              title
               issueType { name }
               subIssuesSummary { total completed percentCompleted }
               subIssues(first: 100) {
@@ -71,7 +76,11 @@ const { gql } = require("../_shared/github");
     );
   }
 
-  appendOutput("should_run", allClosed ? "true" : "false");
+  appendOutputs({
+    should_run: allClosed ? "true" : "false",
+    parent_issue_title: parent?.title ?? "",
+    parent_issue_type: parent?.issueType?.name ?? "",
+  });
 })().catch((error) => {
   console.error("❌ Error:", error);
   appendOutput("should_run", "false");

--- a/.github/actions/check-us-done/check-us-done.js
+++ b/.github/actions/check-us-done/check-us-done.js
@@ -1,10 +1,12 @@
-const { reqEnv, norm, appendOutput } = require("../_shared/utils");
+const { reqEnv, norm, normList, appendOutput } = require("../_shared/utils");
 const { gql } = require("../_shared/github");
 
 (async () => {
   const token = reqEnv("TOKEN");
   const issueNodeId = reqEnv("ISSUE_NODE_ID");
-  const wantedType = norm(process.env.US_ISSUE_TYPE || "User Story");
+  // US_ISSUE_TYPE accepts a comma-separated list of issue types (e.g. "User Story,Enabler Story").
+  // Kept as a single value by default so existing callers are unaffected.
+  const wantedTypes = normList(process.env.US_ISSUE_TYPE || "User Story");
 
   const setFalse = (reason) => {
     if (reason) {
@@ -50,10 +52,10 @@ const { gql } = require("../_shared/github");
   }
 
   const parentType = norm(parent?.issueType?.name || "");
-  const isUserStory = parentType && parentType === wantedType;
+  const isMatchingType = parentType && wantedTypes.includes(parentType);
 
-  if (!isUserStory) {
-    setFalse(`Parent issueType "${parent?.issueType?.name ?? ""}" does not match "${process.env.US_ISSUE_TYPE}".`);
+  if (!isMatchingType) {
+    setFalse(`Parent issueType "${parent?.issueType?.name ?? ""}" does not match any of "${wantedTypes.join(", ")}".`);
     return;
   }
 

--- a/.github/actions/check-us-needs-reopen/action.yaml
+++ b/.github/actions/check-us-needs-reopen/action.yaml
@@ -17,7 +17,7 @@ inputs:
   us_issue_type:
     required: false
     default: "User Story"
-    description: "Expected issue type name for a User Story"
+    description: "Comma-separated list of accepted issue type names (e.g. \"User Story,Enabler Story\"). Defaults to \"User Story\" only."
   completed_status_names:
     required: false
     default: "In Review,Recette,Done"

--- a/.github/actions/check-us-needs-reopen/check-us-needs-reopen.js
+++ b/.github/actions/check-us-needs-reopen/check-us-needs-reopen.js
@@ -1,4 +1,4 @@
-const { reqEnv, norm, appendOutputs } = require("../_shared/utils");
+const { reqEnv, norm, normList, appendOutputs } = require("../_shared/utils");
 const { gql } = require("../_shared/github");
 
 (async () => {
@@ -6,7 +6,8 @@ const { gql } = require("../_shared/github");
   const usIssueNodeId = reqEnv("US_ISSUE_NODE_ID");
   const org = reqEnv("ORG");
   const projectNumber = Number(reqEnv("PROJECT_NUMBER"));
-  const wantedUsType = reqEnv("US_ISSUE_TYPE");
+  // Comma-separated list of accepted issue types (e.g. "User Story,Enabler Story").
+  const wantedTypes = normList(reqEnv("US_ISSUE_TYPE"));
   const completedStatuses = reqEnv("COMPLETED_STATUS_NAMES")
     .split(",")
     .map((s) => norm(s, { stripEmoji: true }))
@@ -68,8 +69,8 @@ const { gql } = require("../_shared/github");
   }
 
   const issueTypeName = issue.issueType?.name ?? "";
-  if (norm(issueTypeName) !== norm(wantedUsType)) {
-    console.log(`Issue is not a User Story. Found issue type: "${issueTypeName}"`);
+  if (!wantedTypes.includes(norm(issueTypeName))) {
+    console.log(`Issue type "${issueTypeName}" does not match any of "${wantedTypes.join(", ")}".`);
     appendOutputs({
       should_reopen: "false",
       current_status: "",

--- a/.github/actions/check-us-test-task/action.yaml
+++ b/.github/actions/check-us-test-task/action.yaml
@@ -8,6 +8,14 @@ inputs:
   us_issue_node_id:
     required: true
     description: "GraphQL node_id of the parent User Story issue"
+  issue_type:
+    required: false
+    default: ""
+    description: "Issue type name of the parent issue, used against qualif_exempt_issue_types"
+  qualif_exempt_issue_types:
+    required: false
+    default: ""
+    description: "Comma-separated list of issue type names exempt from the [QUALIF] sub-task requirement (e.g. \"Bug\"). Empty by default: no exemption, same behaviour as before."
 
 outputs:
   test_task:
@@ -28,4 +36,6 @@ runs:
       env:
         TOKEN: ${{ inputs.token }}
         PARENT_ISSUE_NODE_ID: ${{ inputs.us_issue_node_id }}
+        ISSUE_TYPE: ${{ inputs.issue_type }}
+        QUALIF_EXEMPT_ISSUE_TYPES: ${{ inputs.qualif_exempt_issue_types }}
       run: node "$GITHUB_ACTION_PATH/check-us-test-task.js"

--- a/.github/actions/check-us-test-task/check-us-test-task.js
+++ b/.github/actions/check-us-test-task/check-us-test-task.js
@@ -1,4 +1,4 @@
-const { reqEnv, norm, appendOutput } = require("../_shared/utils");
+const { reqEnv, norm, normList, appendOutput } = require("../_shared/utils");
 const { gql } = require("../_shared/github");
 
 async function hasTestSubTask(token, parentIssueNodeId) {
@@ -79,6 +79,19 @@ async function hasTestSubTask(token, parentIssueNodeId) {
 (async () => {
   const token = reqEnv("TOKEN");
   const parentIssueNodeId = reqEnv("PARENT_ISSUE_NODE_ID");
+  // Optional: comma-separated list of issue types exempt from the [QUALIF]
+  // sub-task requirement (e.g. "Bug"). Empty by default, so existing
+  // callers keep requiring a [QUALIF] sub-task for every type.
+  const exemptTypes = normList(process.env.QUALIF_EXEMPT_ISSUE_TYPES || "");
+  const issueType = norm(process.env.ISSUE_TYPE || "");
+
+  if (exemptTypes.length > 0 && issueType && exemptTypes.includes(issueType)) {
+    console.log(
+      `ℹ️ Issue type "${process.env.ISSUE_TYPE}" is exempt from the [QUALIF] sub-task requirement (QUALIF_EXEMPT_ISSUE_TYPES="${process.env.QUALIF_EXEMPT_ISSUE_TYPES}"). Skipping check.`
+    );
+    appendOutput("test_task", "true");
+    return;
+  }
 
   const result = await hasTestSubTask(token, parentIssueNodeId);
 

--- a/.github/actions/get-issues-in-column/action.yaml
+++ b/.github/actions/get-issues-in-column/action.yaml
@@ -19,7 +19,7 @@ inputs:
   issue_type:
     required: false
     default: "User Story"
-    description: "Issue type to look for in the column"
+    description: "Comma-separated list of issue types to look for in the column (e.g. \"User Story,Enabler Story\"). Defaults to \"User Story\" only."
   sprint:
     required: false
     default: ""

--- a/.github/actions/get-issues-in-column/get-issues-in-column.js
+++ b/.github/actions/get-issues-in-column/get-issues-in-column.js
@@ -1,6 +1,7 @@
 const {
   reqEnv,
   norm,
+  normList,
   appendOutputs,
   isCurrentSprintToken,
   findProjectIterationField,
@@ -30,7 +31,8 @@ const {
   const sprintFieldName = "Sprint";
 
   const targetStatusName = (process.env.TARGET_STATUS_NAME || "In Review").trim();
-  const wantedIssueType = (process.env.ISSUE_TYPE || "User Story").trim();
+  // ISSUE_TYPE accepts a comma-separated list (e.g. "User Story,Enabler Story").
+  const wantedIssueTypes = normList(process.env.ISSUE_TYPE || "User Story", { stripEmoji: true });
   const sprintInput = (process.env.SPRINT || "").trim();
 
   const query = `
@@ -196,7 +198,7 @@ const {
       if (!issue || issue.__typename !== "Issue") continue;
 
       const issueTypeName = issue.issueType?.name ?? "";
-      if (norm(issueTypeName, { stripEmoji: true }) !== norm(wantedIssueType, { stripEmoji: true })) {
+      if (!wantedIssueTypes.includes(norm(issueTypeName, { stripEmoji: true }))) {
         continue;
       }
 
@@ -244,7 +246,7 @@ const {
   });
 
   console.log(
-    `✅ Found ${matchingIssues.length} "${wantedIssueType}" issue(s) in "${targetStatusName}"` +
+    `✅ Found ${matchingIssues.length} "${wantedIssueTypes.join(", ")}" issue(s) in "${targetStatusName}"` +
     `${resolvedSprint ? ` and sprint "${resolvedSprint}"` : ""} (Project #${projectNumber}).`
   );
 })().catch((error) => {

--- a/.github/actions/group-issues-commentary/action.yaml
+++ b/.github/actions/group-issues-commentary/action.yaml
@@ -21,7 +21,7 @@ inputs:
   us_issue_type:
     required: false
     default: "User Story"
-    description: "Name of the User Story issue type in the repo (used to filter issues to move, e.g. if there are multiple issue types in the project)"
+    description: "Comma-separated list of issue type names to include (e.g. \"User Story,Enabler Story\"). Defaults to \"User Story\" only."
 
 runs:
   using: "composite"

--- a/.github/actions/group-issues-commentary/group-issues-commentary.js
+++ b/.github/actions/group-issues-commentary/group-issues-commentary.js
@@ -1,4 +1,4 @@
-const { reqEnv, norm } = require("../_shared/utils");
+const { reqEnv, norm, normList } = require("../_shared/utils");
 const {
   gql,
   restPost,
@@ -13,7 +13,8 @@ const {
   const projectNumber = Number(reqEnv("PROJECT_NUMBER"));
   const fromStatusName = reqEnv("FROM_STATUS_NAME").trim();
   const body = reqEnv("BODY");
-  const wantedUsType = (process.env.US_ISSUE_TYPE || "User Story").trim();
+  // US_ISSUE_TYPE accepts a comma-separated list (e.g. "User Story,Enabler Story").
+  const wantedTypes = normList(process.env.US_ISSUE_TYPE || "User Story", { stripEmoji: true });
   const statusFieldName = "Status";
 
   const query = `
@@ -99,7 +100,7 @@ const {
       const issue = item?.content;
       if (!issue || issue.__typename !== "Issue") continue;
 
-      if (norm(issue.issueType?.name, { stripEmoji: true }) !== norm(wantedUsType, { stripEmoji: true })) {
+      if (!wantedTypes.includes(norm(issue.issueType?.name, { stripEmoji: true }))) {
         continue;
       }
 

--- a/.github/actions/group-issues-status-update/action.yaml
+++ b/.github/actions/group-issues-status-update/action.yaml
@@ -23,7 +23,7 @@ inputs:
   us_issue_type:
     required: false
     default: "User Story"
-    description: "Name of the User Story issue type in the repo (used to filter issues to move, e.g. if there are multiple issue types in the project)"
+    description: "Comma-separated list of issue type names to include (e.g. \"User Story,Enabler Story\"). Defaults to \"User Story\" only."
 
 runs:
   using: "composite"

--- a/.github/actions/group-issues-status-update/group-issues-status-update.js
+++ b/.github/actions/group-issues-status-update/group-issues-status-update.js
@@ -1,4 +1,4 @@
-const { reqEnv, norm } = require("../_shared/utils");
+const { reqEnv, norm, normList } = require("../_shared/utils");
 const {
   gql,
   findProjectSingleSelectField,
@@ -14,7 +14,8 @@ const {
   const statusFieldName = "Status";
   const fromStatusName = (process.env.FROM_STATUS_NAME || "In Review").trim();
   const targetStatusName = (process.env.TARGET_STATUS_NAME || "Recette").trim();
-  const wantedUsType = (process.env.US_ISSUE_TYPE || "User Story").trim();
+  // US_ISSUE_TYPE accepts a comma-separated list (e.g. "User Story,Enabler Story").
+  const wantedTypes = normList(process.env.US_ISSUE_TYPE || "User Story", { stripEmoji: true });
 
   const qProject = `
     query($org: String!, $number: Int!) {
@@ -117,7 +118,7 @@ const {
       const issue = node?.content;
       if (!issue || issue.__typename !== "Issue") continue;
 
-      if (norm(issue.issueType?.name, { stripEmoji: true }) !== norm(wantedUsType, { stripEmoji: true })) {
+      if (!wantedTypes.includes(norm(issue.issueType?.name, { stripEmoji: true }))) {
         continue;
       }
 

--- a/.github/workflows/check-us-completion-workflow.yaml
+++ b/.github/workflows/check-us-completion-workflow.yaml
@@ -26,6 +26,12 @@ on:
         value: ${{ jobs.check.outputs.parent_issue_node_id }}
       parent_issue_number:
         value: ${{ jobs.check.outputs.parent_issue_number }}
+      parent_issue_title:
+        description: "Title of the parent issue"
+        value: ${{ jobs.check.outputs.parent_issue_title }}
+      parent_issue_type:
+        description: "Issue type name of the parent issue (e.g. User Story, Enabler Story)"
+        value: ${{ jobs.check.outputs.parent_issue_type }}
 
 permissions:
   issues: read
@@ -40,6 +46,8 @@ jobs:
       test_task: ${{ steps.check_test_task.outputs.test_task }}
       parent_issue_node_id: ${{ steps.parent.outputs.parent_issue_node_id }}
       parent_issue_number: ${{ steps.parent.outputs.parent_issue_number }}
+      parent_issue_title: ${{ steps.check_us.outputs.parent_issue_title }}
+      parent_issue_type: ${{ steps.check_us.outputs.parent_issue_type }}
 
     steps:
       - name: 👮‍♂️ Check if parent US is complete
@@ -93,13 +101,13 @@ jobs:
           app_private_key: ${{ secrets.GH_APP_TOKEN }}
           owner: ${{ vars.ORG }}
 
-      - name: 💬 Comment missing [QUALIF] task on parent US
+      - name: 💬 Comment missing [QUALIF] task on parent issue
         uses: avenirs-esr/avenirs-workflows/.github/actions/comment-on-issue@main
         with:
           token: ${{ steps.app.outputs.app-token }}
           issue_node_id: ${{ needs.check.outputs.parent_issue_node_id }}
           body: |
-            ⚠️ Cette User Story ne peut pas être considérée comme complète car aucune sous-tâche de test n’a été détectée.
+            ⚠️ **[${{ needs.check.outputs.parent_issue_type }}]** ${{ needs.check.outputs.parent_issue_title }} ne peut pas être considérée comme complète car aucune sous-tâche de test n’a été détectée.
             Merci d’ajouter une sub-task dont le titre contient `[QUALIF]`.
 
   update-us-status:

--- a/.github/workflows/check-us-completion-workflow.yaml
+++ b/.github/workflows/check-us-completion-workflow.yaml
@@ -82,6 +82,8 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           us_issue_node_id: ${{ steps.parent.outputs.parent_issue_node_id }}
+          issue_type: ${{ steps.check_us.outputs.parent_issue_type }}
+          qualif_exempt_issue_types: ${{ vars.QUALIF_EXEMPT_ISSUE_TYPES }}
 
   comment-missing-test-task:
     needs: check

--- a/.github/workflows/qualif-deployment-workflow.yaml
+++ b/.github/workflows/qualif-deployment-workflow.yaml
@@ -261,8 +261,8 @@ jobs:
         with:
           issues_json: ${{ needs.check.outputs.issues_json }}
           count: ${{ needs.check.outputs.count }}
-          header_message: "🧪 Nouvelle(s) US déployée(s) sur qualif et prête(s) pour recette :"
-          empty_message: "ℹ️ Aucune User Story déployée sur qualif."
+          header_message: "🧪 Nouvel(s) élément(s) déployé(s) sur qualif et prêt(s) pour recette :"
+          empty_message: "ℹ️ Aucun élément déployé sur qualif."
 
       - name: 🔍 Get US in In Review
         id: get_us_in_recette
@@ -287,7 +287,7 @@ jobs:
 
             ${{ steps.build_message.outputs.message }}
 
-            Pour info, il y a ${{ steps.get_us_in_recette.outputs.count }} US dans la colonne Recette ( ${{ vars.COFOLIO_PROJECT_URL }} ).
+            Pour info, il y a ${{ steps.get_us_in_recette.outputs.count }} élément(s) dans la colonne Recette ( ${{ vars.COFOLIO_PROJECT_URL }} ).
 
   notify:
     name: 🚀 Notify Rocket.Chat


### PR DESCRIPTION
Permet à us_issue_type/issue_type d'accepter une liste CSV (ex: 'User Story,Enabler Story'). 
Défaut inchangé, aucune régression.